### PR TITLE
chore(ci): update params

### DIFF
--- a/.ci.infra
+++ b/.ci.infra
@@ -2,4 +2,4 @@
 
 @Library('camunda-ci') _
 
-buildDockerImage([registry: 'ci-v2'])
+buildDockerImage([registry: 'ci'])


### PR DESCRIPTION
related to INFRA-2542
After the `ci-v2` migration, the references were updated and `ci-v2` doesn't exist anymore. `ci` will map to the same gcp project as `ci-v2`, so nothing changes.